### PR TITLE
Revert "settings: Remove lock screen blur stuff breaking build"

### DIFF
--- a/res/xml/security_settings_password_sub.xml
+++ b/res/xml/security_settings_password_sub.xml
@@ -58,4 +58,10 @@
             android:title="@string/lockscreen_weather_enabled_title"
             android:defaultValue="false"/>
 
+        <cyanogenmod.preference.CMSecureSettingSwitchPreference
+            android:key="lock_screen_blur_enabled"
+            android:title="@string/lockscreen_blur_enabled_title"
+            android:defaultValue="true"
+            cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
+
 </PreferenceScreen>

--- a/res/xml/security_settings_pattern_sub.xml
+++ b/res/xml/security_settings_pattern_sub.xml
@@ -62,4 +62,10 @@
             android:title="@string/lockscreen_weather_enabled_title"
             android:defaultValue="false"/>
 
+        <cyanogenmod.preference.CMSecureSettingSwitchPreference
+            android:key="lock_screen_blur_enabled"
+            android:title="@string/lockscreen_blur_enabled_title"
+            android:defaultValue="true"
+            cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
+
 </PreferenceScreen>

--- a/res/xml/security_settings_pin_sub.xml
+++ b/res/xml/security_settings_pin_sub.xml
@@ -63,4 +63,10 @@
             android:title="@string/lockscreen_weather_enabled_title"
             android:defaultValue="false"/>
 
+        <cyanogenmod.preference.CMSecureSettingSwitchPreference
+            android:key="lock_screen_blur_enabled"
+            android:title="@string/lockscreen_blur_enabled_title"
+            android:defaultValue="true"
+            cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
+
 </PreferenceScreen>

--- a/res/xml/security_settings_slide_sub.xml
+++ b/res/xml/security_settings_slide_sub.xml
@@ -42,4 +42,10 @@
             android:title="@string/lockscreen_weather_enabled_title"
             android:defaultValue="false"/>
 
+        <cyanogenmod.preference.CMSecureSettingSwitchPreference
+            android:key="lock_screen_blur_enabled"
+            android:title="@string/lockscreen_blur_enabled_title"
+            android:defaultValue="true"
+            cm:requiresConfig="@*android:bool/config_uiBlurEnabled" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Blur support is now back in the framework.
Also adjust the required overlay to fit the new one.

This reverts commit 695ef5ffa59ce9e5dc2934cf01db75c74ce8c786.

Change-Id: Ie9073ba0b0fcaebae7a0e2791e0d94d2a3f40fa4